### PR TITLE
프로필 변경, 모임 입장 제한 QA내역 반영

### DIFF
--- a/MARU/MARU.xcodeproj/project.pbxproj
+++ b/MARU/MARU.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		F22AB7C826CA962A006CD9C0 /* CreateQuizCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F22AB7C726CA962A006CD9C0 /* CreateQuizCell.swift */; };
 		F22AB7CA26CA976F006CD9C0 /* CreateQuizViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F22AB7C926CA976F006CD9C0 /* CreateQuizViewModel.swift */; };
 		F231C40726E2801C00642130 /* EvaluateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F231C40626E2801C00642130 /* EvaluateViewController.swift */; };
+		F235E2D6278B417700A30FCA /* NSMutableAttributedString+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F235E2D5278B417700A30FCA /* NSMutableAttributedString+.swift */; };
 		F2377D2926A567E300F1FAA4 /* LibraryDiaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2377D2826A567E300F1FAA4 /* LibraryDiaryCell.swift */; };
 		F2377D2B26A586CE00F1FAA4 /* UITableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2377D2A26A586CE00F1FAA4 /* UITableView+.swift */; };
 		F24E335A27397986001E3F5B /* NicknameCheckViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24E335927397986001E3F5B /* NicknameCheckViewModel.swift */; };
@@ -343,6 +344,7 @@
 		F22AB7C726CA962A006CD9C0 /* CreateQuizCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateQuizCell.swift; sourceTree = "<group>"; };
 		F22AB7C926CA976F006CD9C0 /* CreateQuizViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateQuizViewModel.swift; sourceTree = "<group>"; };
 		F231C40626E2801C00642130 /* EvaluateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluateViewController.swift; sourceTree = "<group>"; };
+		F235E2D5278B417700A30FCA /* NSMutableAttributedString+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+.swift"; sourceTree = "<group>"; };
 		F2377D2826A567E300F1FAA4 /* LibraryDiaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryDiaryCell.swift; sourceTree = "<group>"; };
 		F2377D2A26A586CE00F1FAA4 /* UITableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+.swift"; sourceTree = "<group>"; };
 		F24E335927397986001E3F5B /* NicknameCheckViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameCheckViewModel.swift; sourceTree = "<group>"; };
@@ -718,6 +720,7 @@
 				C5CE01942714855600CE4E4A /* RxViewController+.swift */,
 				C56C1CF3275A6568009B6403 /* Observable+.swift */,
 				F22333CD277B7C0700C7C2F4 /* Array+.swift */,
+				F235E2D5278B417700A30FCA /* NSMutableAttributedString+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1275,6 +1278,7 @@
 				F22333CC277B6E0200C7C2F4 /* BookShelfModel.swift in Sources */,
 				C5CE018D2713D81F00CE4E4A /* JoinCollectionViewCell.swift in Sources */,
 				F28FF226270A04590026FF8A /* JoinViewModel.swift in Sources */,
+				F235E2D6278B417700A30FCA /* NSMutableAttributedString+.swift in Sources */,
 				F22333CE277B7C0700C7C2F4 /* Array+.swift in Sources */,
 				776AF4F32641B0BE0020D2D8 /* MaruSearchView.swift in Sources */,
 				C5ACA4C126B673640089C50C /* LibraryTitleCell.swift in Sources */,

--- a/MARU/MARU/Global/Extensions/NSMutableAttributedString+.swift
+++ b/MARU/MARU/Global/Extensions/NSMutableAttributedString+.swift
@@ -1,0 +1,26 @@
+//
+//  NSMutableAttributedString+.swift
+//  MARU
+//
+//  Created by 이윤진 on 2022/01/10.
+//
+
+import Foundation
+import UIKit
+
+extension NSMutableAttributedString {
+
+  func bold(string: String, fontSize: CGFloat) -> NSMutableAttributedString {
+    let font = UIFont.boldSystemFont(ofSize: fontSize)
+    let attributes: [NSAttributedString.Key: Any] = [.font: font]
+    self.append(NSAttributedString(string: string, attributes: attributes))
+    return self
+  }
+
+  func regular(string: String, fontSize: CGFloat) -> NSMutableAttributedString {
+    let font = UIFont.systemFont(ofSize: fontSize)
+    let attributes: [NSAttributedString.Key: Any] = [.font: font]
+    self.append(NSAttributedString(string: string, attributes: attributes))
+    return self
+  }
+}

--- a/MARU/MARU/Screens/Join/View/JoinViewController.swift
+++ b/MARU/MARU/Screens/Join/View/JoinViewController.swift
@@ -300,12 +300,12 @@ extension JoinViewController {
           self.showToast("유저 본인이 개설한 모임에는 참여할 수 없습니다.")
           return
         }
-        if isFailedGroupQuiz == false && canJoinGroup == true {
+        if !isFailedGroupQuiz && canJoinGroup {
           let viewController = QuizViewController(groupID: self.groupID)
           viewController.modalPresentationStyle = .fullScreen
           self.present(viewController, animated: true, completion: nil)
         }
-        if isFailedGroupQuiz == true && canJoinGroup == true {
+        if isFailedGroupQuiz && canJoinGroup {
           self.showToast(
             """
             5문제중 3문제 이상 맞춰야 모임 입장이 가능합니다.
@@ -313,10 +313,10 @@ extension JoinViewController {
             """
           )
         }
-        if isFailedGroupQuiz == false && canJoinGroup == false {
+        if !isFailedGroupQuiz && !canJoinGroup {
           self.showToast("인원이 꽉 찼어요:( 직접 모임을 개설해보세요🤓")
         }
-        if isFailedGroupQuiz == true && canJoinGroup == false {
+        if isFailedGroupQuiz && !canJoinGroup {
           self.showToast(
             """
             5문제중 3문제 이상 맞춰야 모임 입장이 가능합니다.

--- a/MARU/MARU/Screens/Join/View/JoinViewController.swift
+++ b/MARU/MARU/Screens/Join/View/JoinViewController.swift
@@ -124,20 +124,13 @@ final class JoinViewController: BaseViewController {
       scoreStateLabel.text = "\(groups.leaderScore)"
       partyStateLabel.text = "\(groups.userCount)/5"
       contentLabel.text = groups.description
-      // TODO: - 이 부분 좀 더 수정 하고 싶음
-      if UserDefaultHandler.shared.userName != groups.nickname {
-        if groups.isFailedGroupQuiz == false && groups.canJoinGroup == false {
-          self.entryButton.backgroundColor = .lightGray
-        }
-        if groups.isFailedGroupQuiz == true && groups.canJoinGroup == false {
-          self.entryButton.backgroundColor = .lightGray
-        }
-        if groups.isFailedGroupQuiz == true && groups.canJoinGroup == true {
-          self.entryButton.backgroundColor = .lightGray
-        }
-      }
-      if UserDefaultHandler.shared.userName == groups.nickname {
+      guard UserDefaultHandler.shared.userName != groups.nickname else {
         self.entryButton.backgroundColor = .lightGray
+        return
+      }
+      guard groups.isFailedGroupQuiz == false, groups.canJoinGroup == true else {
+        self.entryButton.backgroundColor = .lightGray
+        return
       }
     }
   }
@@ -298,37 +291,38 @@ extension JoinViewController {
     entryButton.rx.tap
       .subscribe(onNext: { [weak self] _ in
         guard let self = self else { return }
+        guard let groups = self.data?.groups else { return }
         let savedNickname = UserDefaultHandler.shared.userName
-        let nickname = self.data?.groups?.nickname
-        let isFailedGroupQuiz = self.data?.groups?.isFailedGroupQuiz
-        let canJoinGroup = self.data?.groups?.canJoinGroup
-        if savedNickname != nickname {
-          if isFailedGroupQuiz == false && canJoinGroup == true {
-            let viewController = QuizViewController(groupID: self.groupID)
-            viewController.modalPresentationStyle = .fullScreen
-            self.present(viewController, animated: true, completion: nil)
-          }
-          if isFailedGroupQuiz == true && canJoinGroup == true {
-            self.showToast(
-              """
-              5문제중 3문제 이상 맞춰야 모임 입장이 가능합니다.
-              기회는 단 한 번입니다! 재입장은 불가합니다.
-              """
-            )
-          }
-          if isFailedGroupQuiz == false && canJoinGroup == false {
-            self.showToast("인원이 꽉 찼어요:( 직접 모임을 개설해보세요🤓")
-          }
-          if isFailedGroupQuiz == true && canJoinGroup == false {
-            self.showToast(
-              """
-              5문제중 3문제 이상 맞춰야 모임 입장이 가능합니다.
-              기회는 단 한 번입니다! 재입장은 불가합니다.
-              """
-            )
-          }
-        } else {
+        let nickname = groups.nickname
+        let isFailedGroupQuiz = groups.isFailedGroupQuiz
+        let canJoinGroup = groups.canJoinGroup
+        guard savedNickname != nickname else {
           self.showToast("유저 본인이 개설한 모임에는 참여할 수 없습니다.")
+          return
+        }
+        if isFailedGroupQuiz == false && canJoinGroup == true {
+          let viewController = QuizViewController(groupID: self.groupID)
+          viewController.modalPresentationStyle = .fullScreen
+          self.present(viewController, animated: true, completion: nil)
+        }
+        if isFailedGroupQuiz == true && canJoinGroup == true {
+          self.showToast(
+            """
+            5문제중 3문제 이상 맞춰야 모임 입장이 가능합니다.
+            기회는 단 한 번입니다! 재입장은 불가합니다.
+            """
+          )
+        }
+        if isFailedGroupQuiz == false && canJoinGroup == false {
+          self.showToast("인원이 꽉 찼어요:( 직접 모임을 개설해보세요🤓")
+        }
+        if isFailedGroupQuiz == true && canJoinGroup == false {
+          self.showToast(
+            """
+            5문제중 3문제 이상 맞춰야 모임 입장이 가능합니다.
+            기회는 단 한 번입니다! 재입장은 불가합니다.
+            """
+          )
         }
       })
       .disposed(by: disposeBag)

--- a/MARU/MARU/Screens/Join/View/JoinViewController.swift
+++ b/MARU/MARU/Screens/Join/View/JoinViewController.swift
@@ -110,8 +110,10 @@ final class JoinViewController: BaseViewController {
   fileprivate var data: GroupInformation? {
     didSet {
       if let imageURL = data?.groups?.image {
-        bookImageView.image(url: imageURL,
-                            defaultImage: Image.defalutImage ?? UIImage())
+        bookImageView.image(
+          url: imageURL,
+          defaultImage: Image.defalutImage ?? UIImage()
+        )
       }
       bookTitleLabel.text = data?.groups?.title
       let text = "토론이\(data?.groups?.remainingDay ?? -1)일 남았습니다."
@@ -125,7 +127,7 @@ final class JoinViewController: BaseViewController {
       scoreStateLabel.text = "\(data?.groups?.leaderScore ?? -1)"
       partyStateLabel.text = "\(data?.groups?.userCount ?? -1)/5"
       contentLabel.text = data?.groups?.description
-      // TODO: - 이 부분 좀 더 수정 필요해보임
+      // TODO: - 이 부분 좀 더 수정 하고 싶음
       if UserDefaultHandler.shared.userName != self.data?.groups?.nickname {
         if self.data?.groups?.isFailedGroupQuiz == false && self.data?.groups?.canJoinGroup == false {
           self.entryButton.backgroundColor = .lightGray
@@ -143,12 +145,12 @@ final class JoinViewController: BaseViewController {
     }
   }
   private let groupID: Int
+
   override func viewDidLoad() {
     super.viewDidLoad()
     setLayout()
     setGradientViewLayout()
     bind()
-    // Do any additional setup after loading the view.
   }
 
   override func viewWillAppear(_ animated: Bool) {

--- a/MARU/MARU/Screens/Join/View/JoinViewController.swift
+++ b/MARU/MARU/Screens/Join/View/JoinViewController.swift
@@ -125,6 +125,7 @@ final class JoinViewController: BaseViewController {
       scoreStateLabel.text = "\(data?.groups?.leaderScore ?? -1)"
       partyStateLabel.text = "\(data?.groups?.userCount ?? -1)/5"
       contentLabel.text = data?.groups?.description
+      // TODO: - 이 부분 좀 더 수정 필요해보임
       if UserDefaultHandler.shared.userName != self.data?.groups?.nickname {
         if self.data?.groups?.isFailedGroupQuiz == false && self.data?.groups?.canJoinGroup == false {
           self.entryButton.backgroundColor = .lightGray

--- a/MARU/MARU/Screens/Join/View/JoinViewController.swift
+++ b/MARU/MARU/Screens/Join/View/JoinViewController.swift
@@ -109,37 +109,34 @@ final class JoinViewController: BaseViewController {
   private let viewModel = JoinViewModel()
   fileprivate var data: GroupInformation? {
     didSet {
-      if let imageURL = data?.groups?.image {
-        bookImageView.image(
-          url: imageURL,
-          defaultImage: Image.defalutImage ?? UIImage()
-        )
-      }
-      bookTitleLabel.text = data?.groups?.title
-      let text = "토론이\(data?.groups?.remainingDay ?? -1)일 남았습니다."
+      guard let groups = data?.groups else { return }
+      let imageURL = groups.image
+      bookImageView.image(url: imageURL, defaultImage: Image.defalutImage ?? UIImage())
+      bookTitleLabel.text = groups.title
+      let text = "토론이\(groups.remainingDay)일 남았습니다."
       let attributedString = NSMutableAttributedString(string: text)
       attributedString.addAttribute(
         .foregroundColor,
         value: UIColor.cornFlowerBlue,
-        range: (text as NSString).range(of: "\(data?.groups?.remainingDay ?? -1)"))
+        range: (text as NSString).range(of: "\(groups.remainingDay)"))
       leftTimeLabel.attributedText = attributedString
-      leadNameLabel.text = data?.groups?.nickname
-      scoreStateLabel.text = "\(data?.groups?.leaderScore ?? -1)"
-      partyStateLabel.text = "\(data?.groups?.userCount ?? -1)/5"
-      contentLabel.text = data?.groups?.description
+      leadNameLabel.text = groups.nickname
+      scoreStateLabel.text = "\(groups.leaderScore)"
+      partyStateLabel.text = "\(groups.userCount)/5"
+      contentLabel.text = groups.description
       // TODO: - 이 부분 좀 더 수정 하고 싶음
-      if UserDefaultHandler.shared.userName != self.data?.groups?.nickname {
-        if self.data?.groups?.isFailedGroupQuiz == false && self.data?.groups?.canJoinGroup == false {
+      if UserDefaultHandler.shared.userName != groups.nickname {
+        if groups.isFailedGroupQuiz == false && groups.canJoinGroup == false {
           self.entryButton.backgroundColor = .lightGray
         }
-        if self.data?.groups?.isFailedGroupQuiz == true && self.data?.groups?.canJoinGroup == false {
+        if groups.isFailedGroupQuiz == true && groups.canJoinGroup == false {
           self.entryButton.backgroundColor = .lightGray
         }
-        if self.data?.groups?.isFailedGroupQuiz == true && self.data?.groups?.canJoinGroup == true {
+        if groups.isFailedGroupQuiz == true && groups.canJoinGroup == true {
           self.entryButton.backgroundColor = .lightGray
         }
       }
-      if UserDefaultHandler.shared.userName == self.data?.groups?.nickname {
+      if UserDefaultHandler.shared.userName == groups.nickname {
         self.entryButton.backgroundColor = .lightGray
       }
     }
@@ -197,7 +194,7 @@ extension JoinViewController {
       make.leading.equalTo(view.safeAreaLayoutGuide)
       make.trailing.equalTo(view.safeAreaLayoutGuide)
       make.bottom.equalTo(view)
-      make.height.equalTo(49)
+      make.height.equalTo(60)
     }
     gradientImageView.adds([
       bookTitleLabel,

--- a/MARU/MARU/Screens/Join/View/JoinViewController.swift
+++ b/MARU/MARU/Screens/Join/View/JoinViewController.swift
@@ -125,6 +125,20 @@ final class JoinViewController: BaseViewController {
       scoreStateLabel.text = "\(data?.groups?.leaderScore ?? -1)"
       partyStateLabel.text = "\(data?.groups?.userCount ?? -1)/5"
       contentLabel.text = data?.groups?.description
+      if UserDefaultHandler.shared.userName != self.data?.groups?.nickname {
+        if self.data?.groups?.isFailedGroupQuiz == false && self.data?.groups?.canJoinGroup == false {
+          self.entryButton.backgroundColor = .lightGray
+        }
+        if self.data?.groups?.isFailedGroupQuiz == true && self.data?.groups?.canJoinGroup == false {
+          self.entryButton.backgroundColor = .lightGray
+        }
+        if self.data?.groups?.isFailedGroupQuiz == true && self.data?.groups?.canJoinGroup == true {
+          self.entryButton.backgroundColor = .lightGray
+        }
+      }
+      if UserDefaultHandler.shared.userName == self.data?.groups?.nickname {
+        self.entryButton.backgroundColor = .lightGray
+      }
     }
   }
   private let groupID: Int
@@ -179,7 +193,7 @@ extension JoinViewController {
     entryButton.snp.makeConstraints { (make) in
       make.leading.equalTo(view.safeAreaLayoutGuide)
       make.trailing.equalTo(view.safeAreaLayoutGuide)
-      make.bottom.equalTo(view.safeAreaLayoutGuide)
+      make.bottom.equalTo(view)
       make.height.equalTo(49)
     }
     gradientImageView.adds([
@@ -284,12 +298,37 @@ extension JoinViewController {
     entryButton.rx.tap
       .subscribe(onNext: { [weak self] _ in
         guard let self = self else { return }
-        if self.data?.groups?.isFailedGroupQuiz == false && self.data?.groups?.canJoinGroup == true {
-          let viewController = QuizViewController(groupID: self.groupID)
-          viewController.modalPresentationStyle = .fullScreen
-          self.present(viewController, animated: true, completion: nil)
+        let savedNickname = UserDefaultHandler.shared.userName
+        let nickname = self.data?.groups?.nickname
+        let isFailedGroupQuiz = self.data?.groups?.isFailedGroupQuiz
+        let canJoinGroup = self.data?.groups?.canJoinGroup
+        if savedNickname != nickname {
+          if isFailedGroupQuiz == false && canJoinGroup == true {
+            let viewController = QuizViewController(groupID: self.groupID)
+            viewController.modalPresentationStyle = .fullScreen
+            self.present(viewController, animated: true, completion: nil)
+          }
+          if isFailedGroupQuiz == true && canJoinGroup == true {
+            self.showToast(
+              """
+              5문제중 3문제 이상 맞춰야 모임 입장이 가능합니다.
+              기회는 단 한 번입니다! 재입장은 불가합니다.
+              """
+            )
+          }
+          if isFailedGroupQuiz == false && canJoinGroup == false {
+            self.showToast("인원이 꽉 찼어요:( 직접 모임을 개설해보세요🤓")
+          }
+          if isFailedGroupQuiz == true && canJoinGroup == false {
+            self.showToast(
+              """
+              5문제중 3문제 이상 맞춰야 모임 입장이 가능합니다.
+              기회는 단 한 번입니다! 재입장은 불가합니다.
+              """
+            )
+          }
         } else {
-          self.showToast("참여가 불가한 토론방입니다.")
+          self.showToast("유저 본인이 개설한 모임에는 참여할 수 없습니다.")
         }
       })
       .disposed(by: disposeBag)

--- a/MARU/MARU/Screens/Library/BookFavoritesViewController.swift
+++ b/MARU/MARU/Screens/Library/BookFavoritesViewController.swift
@@ -104,27 +104,12 @@ extension BookFavoritesViewController {
 }
 
 extension BookFavoritesViewController: UICollectionViewDataSource {
-//  func numberOfSections(in collectionView: UICollectionView) -> Int {
-//    guard let count = data?.bookcase.count else { return 1 }
-//    print("ccc", count)
-//    if count % 3 == 0 {
-//      return count / 3
-//    } else if count > 3 {
-//      return count / 3 + 1
-//    }
-//    return 1
-//  }
-
   func collectionView(
     _ collectionView: UICollectionView,
     cellForItemAt indexPath: IndexPath
   ) -> UICollectionViewCell {
     let cell: BookFavoritesCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
     cell.rx.dataBinder.onNext(data?.bookcase[indexPath.item])
-//    let cell: BookFavoritesShelfCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
-//    cell.collectionView.backgroundView = bookShelfImageView
-//    cell.rx.binder.onNext(data?.bookcase ?? [])
-//    // TODO: - 이 부분 고쳐야함
     cell.rx.didTapContentView
       .subscribe( onNext: { [weak self] _ in
         guard

--- a/MARU/MARU/Screens/Popup/BookAlertViewController.swift
+++ b/MARU/MARU/Screens/Popup/BookAlertViewController.swift
@@ -23,9 +23,11 @@ final class BookAlertViewController: UIViewController {
   }
 
   private let titleLabel = UILabel().then {
-    $0.text = "(책 제목) 책이"
+    $0.text = "(책 제목)이(가)"
     $0.textAlignment = .center
-    $0.font = .systemFont(ofSize: 13, weight: .regular)
+    $0.font = .systemFont(ofSize: 13, weight: .bold)
+    $0.attributedText = NSMutableAttributedString()
+      .regular(string: "이(가)", fontSize: 13)
   }
 
   private let stateLabel = UILabel().then {

--- a/MARU/MARU/Screens/Profile/View/ProfileChangeViewController.swift
+++ b/MARU/MARU/Screens/Profile/View/ProfileChangeViewController.swift
@@ -21,6 +21,7 @@ final class ProfileChangeViewController: UIViewController {
     $0.setTitle("완료", for: .normal)
     $0.setTitleColor(.subText, for: .normal)
     $0.titleLabel?.font = .systemFont(ofSize: 12, weight: .bold)
+    $0.isEnabled = false
   }
   private let profileImageView = UIImageView().then {
     $0.image = Image.group1029
@@ -73,6 +74,8 @@ final class ProfileChangeViewController: UIViewController {
 
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    profileBind()
+    bind()
   }
 
   init(imageURL: String) {
@@ -208,7 +211,7 @@ extension ProfileChangeViewController {
   }
 
   private func profileBind() {
-    profileImageView.image(url: imageURL)
+    profileImageView.image(url: imageURL, defaultImage: Image.group1029 ?? UIImage())
     let didTapSubmitButton = submitButton.rx.tap
       .map { [weak self] _ -> (nickname: String, image: UIImage) in
         guard let self = self,

--- a/MARU/MARU/Screens/Profile/View/ProfileChangeViewController.swift
+++ b/MARU/MARU/Screens/Profile/View/ProfileChangeViewController.swift
@@ -77,8 +77,6 @@ final class ProfileChangeViewController: UIViewController {
 
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
-    profileBind()
-    bind()
   }
 
   init(imageURL: String) {

--- a/MARU/MARU/Screens/Profile/View/ProfileChangeViewController.swift
+++ b/MARU/MARU/Screens/Profile/View/ProfileChangeViewController.swift
@@ -202,7 +202,7 @@ extension ProfileChangeViewController {
       .flatMap { NetworkService.shared.auth.nickname(name: $0 ?? "").map { $0.status} }
       .subscribe(onNext: { [weak self] statusCode in
         guard let self = self else { return }
-        if statusCode == 200 {
+        if statusCode == 200 || statusCode == 201 {
           self.nicknameCheckLabel.textColor = .subText
           self.nicknameCheckLabel.text = "사용 가능한 닉네임입니다."
           self.submitButton.setTitleColor(.mainBlue, for: .normal)

--- a/MARU/MARU/Screens/Profile/View/ProfileChangeViewController.swift
+++ b/MARU/MARU/Screens/Profile/View/ProfileChangeViewController.swift
@@ -65,6 +65,7 @@ final class ProfileChangeViewController: UIViewController {
   let picker = UIImagePickerController()
   let disposeBag = DisposeBag()
   private var savedNickname: String?
+
   override func viewDidLoad() {
     super.viewDidLoad()
     picker.delegate = self
@@ -88,6 +89,7 @@ final class ProfileChangeViewController: UIViewController {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
   private func render() {
     view.backgroundColor = .white
     view.adds([
@@ -171,6 +173,7 @@ extension ProfileChangeViewController {
   private func deletePhoto() {
     profileImageView.image = Image.group1029
   }
+
   private func openLibrary() {
     picker.sourceType = .photoLibrary
     present(picker, animated: false, completion: nil)
@@ -201,7 +204,6 @@ extension ProfileChangeViewController {
       .flatMap { NetworkService.shared.auth.nickname(name: $0 ?? "").map { $0.status} }
       .subscribe(onNext: { [weak self] statusCode in
         guard let self = self else { return }
-        // TODO: - 서버 변경하는 대로 반영할 예정입니다.
         if statusCode == 200 {
           self.nicknameCheckLabel.textColor = .subText
           self.nicknameCheckLabel.text = "사용 가능한 닉네임입니다."

--- a/MARU/MARU/Screens/Profile/View/ProfileChangeViewController.swift
+++ b/MARU/MARU/Screens/Profile/View/ProfileChangeViewController.swift
@@ -168,7 +168,6 @@ extension ProfileChangeViewController {
 
   private func deletePhoto() {
     profileImageView.image = Image.group1029
-    submitButton.setTitleColor(.subText, for: .normal)
   }
   private func openLibrary() {
     picker.sourceType = .photoLibrary
@@ -202,9 +201,15 @@ extension ProfileChangeViewController {
         if statusCode == 200 {
           self.nicknameCheckLabel.textColor = .subText
           self.nicknameCheckLabel.text = "사용 가능한 닉네임입니다."
-        } else {
+          self.submitButton.setTitleColor(.mainBlue, for: .normal)
+          self.submitButton.isEnabled = true
+        }
+        if statusCode == 400 {
           self.nicknameCheckLabel.textColor = .negative
           self.nicknameCheckLabel.text = "이미 존재하는 이름입니다."
+          self.submitButton.setTitleColor(.subText, for: .normal)
+          self.submitButton.isEnabled = true
+
         }
       })
       .disposed(by: disposeBag)
@@ -238,9 +243,10 @@ extension ProfileChangeViewController: UIImagePickerControllerDelegate, UINaviga
     didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
   ) {
     if let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage {
-      profileImageView.contentMode = .scaleAspectFit
+      profileImageView.contentMode = .scaleAspectFill
       profileImageView.image = image
       submitButton.setTitleColor(.mainBlue, for: .normal)
+      submitButton.isEnabled = true
     }
     dismiss(animated: true, completion: nil)
   }


### PR DESCRIPTION
## 종류
- [ ] New Feature
- [ ] Change
- [x] Bug fix
- [ ] Setup (CI / CD)

## 개요
2차 QA 내역에 있던 프로필 변경 문제와 모임 입장 제한 문제를 다시 해결했습니다
## 변경 사항
1. 프로필 변경 쪽에 닉네임과 이미지 UserDefault 다시 저장하게끔 설정했습니다.
2. 중복 닉네임 문제 해결완료!
3. 모임입장 제한 조건을 모두 설정해놓았습니다.
4. 두 화면 모두 상태별로 버튼 비활성화/활성화 처리 걸어두었습니다.
## 참고 사항
1. JoinViewController(모임입장화면) 쪽에서 
조건에 따라 버튼의 색깔을 파란색/회색으로 변경이 되도록 didSet에서 처리해놓았는데 
이게 맞는것인지요,,bind부분에 넣으려다 헤맸었습니다. 
이 부분은 나중에 다시 고쳐볼 수 있을 거 같아 mark주석처리 해두었습니다.