### PR TITLE
팝업화면 볼드체 적용, 서재탭 emptyview QA내역 반영

### DIFF
--- a/MARU/MARU/Global/Resources/Image.swift
+++ b/MARU/MARU/Global/Resources/Image.swift
@@ -80,4 +80,5 @@ enum Image {
   static let savedButtonActive = UIImage(named: "savedButtonActive")
   static let invalidName4 = UIImage(named: "invalidName4")
   static let vector22 = UIImage(named: "vector22")
+  static let group841gray = UIImage(named: "group841")
 }

--- a/MARU/MARU/Screens/Library/BookFavoritesViewController.swift
+++ b/MARU/MARU/Screens/Library/BookFavoritesViewController.swift
@@ -65,19 +65,19 @@ final class BookFavoritesViewController: BaseViewController {
 
 extension BookFavoritesViewController {
   private func render() {
-    view.adds([
-      emptyView,
-      collectionView
-    ])
-
-    emptyView.snp.makeConstraints { make in
-      make.edges.equalToSuperview()
+    view.add(collectionView) { view in
+      view.snp.makeConstraints {
+        $0.edges.equalToSuperview()
+      }
     }
-
+    view.add(emptyView) { view in
+      view.snp.makeConstraints {
+        $0.edges.equalToSuperview()
+      }
+    }
     collectionView.snp.makeConstraints { make in
       make.edges.equalToSuperview()
     }
-
     collectionView.delegate = self
     collectionView.dataSource = self
   }
@@ -92,6 +92,7 @@ extension BookFavoritesViewController {
           self.emptyView.isHidden = true
         }
         self.data = data
+        self.collectionView.reloadData()
       })
       .disposed(by: disposeBag)
     viewDidLoadPublisher.onNext(())

--- a/MARU/MARU/Screens/Library/BookFavoritesViewController.swift
+++ b/MARU/MARU/Screens/Library/BookFavoritesViewController.swift
@@ -11,7 +11,7 @@ import RxCocoa
 
 final class BookFavoritesViewController: BaseViewController {
   private let emptyView = EmptyView(
-    image: Image.group841?.withRenderingMode(.alwaysTemplate) ?? UIImage(),
+    image: Image.autoStories?.withRenderingMode(.alwaysTemplate) ?? UIImage(),
     content: """
     모임하고 싶은 책이 아직 없어요.
     +버튼을 눌러 서재를 채워주세요.

--- a/MARU/MARU/Screens/Library/Cell/MyBookCaseCell.swift
+++ b/MARU/MARU/Screens/Library/Cell/MyBookCaseCell.swift
@@ -23,7 +23,7 @@ final class MyBookCaseCell: UICollectionViewCell {
   }()
 
   let noResultImageView = UIImageView().then {
-    $0.backgroundColor = .white
+    $0.backgroundColor = .none
     $0.image = Image.vector21
     $0.isHidden = true
   }

--- a/MARU/MARU/Screens/Library/Cell/MyLibraryCell.swift
+++ b/MARU/MARU/Screens/Library/Cell/MyLibraryCell.swift
@@ -29,14 +29,21 @@ final class MyLibraryCell: UICollectionViewCell {
   }
 
   let bookImage = UIImageView().then {
-    $0.image = Image.autoStories
+    $0.image = Image.group841gray
   }
 
   let emptyLabel = UILabel().then {
     $0.font = .systemFont(ofSize: 14, weight: .medium)
     $0.textColor = .subText
     $0.textAlignment = .center
-    $0.text = "서재를 채워주세요 :)"
+    $0.text = "채팅방 속 버튼을 통해"
+  }
+
+  let emptySubLabel = UILabel().then {
+    $0.font = .systemFont(ofSize: 14, weight: .medium)
+    $0.textColor = .subText
+    $0.textAlignment = .center
+    $0.text = "모임을 담아볼까요?"
   }
 
   fileprivate var groupData: [KeepGroup] = [] {
@@ -83,6 +90,12 @@ final class MyLibraryCell: UICollectionViewCell {
       label.snp.makeConstraints {
         $0.centerX.equalTo(self.noResultImageView)
         $0.top.equalTo(self.bookImage.snp.bottom).offset(4)
+      }
+    }
+    noResultImageView.add(emptySubLabel) { label in
+      label.snp.makeConstraints {
+        $0.centerX.equalTo(self.emptyLabel)
+        $0.top.equalTo(self.emptyLabel.snp.bottom).offset(1)
       }
     }
     collectionView.delegate = self

--- a/MARU/MARU/Screens/Library/ResultBookViewController.swift
+++ b/MARU/MARU/Screens/Library/ResultBookViewController.swift
@@ -170,7 +170,7 @@ extension ResultBookViewController: UICollectionViewDelegate {
     if data.hasMyBookcase == false {
       let viewController = BookAlertViewController(
         Image.coolicon ?? UIImage(),
-        "\(title)이(가)",
+        "\(title)",
         "성공적으로 서재에 담겼습니다.",
         data
       )
@@ -180,7 +180,7 @@ extension ResultBookViewController: UICollectionViewDelegate {
     } else {
       let viewController = BookAlertViewController(
         Image.group1036 ?? UIImage(),
-        "\(title)이(가)",
+        "\(title)",
         "이미 담겨있습니다.",
         data
       )

--- a/MARU/MARU/Screens/Popup/BookAlertViewController.swift
+++ b/MARU/MARU/Screens/Popup/BookAlertViewController.swift
@@ -26,8 +26,12 @@ final class BookAlertViewController: UIViewController {
     $0.text = "(책 제목)이(가)"
     $0.textAlignment = .center
     $0.font = .systemFont(ofSize: 13, weight: .bold)
-    $0.attributedText = NSMutableAttributedString()
-      .regular(string: "이(가)", fontSize: 13)
+  }
+
+  private let guideLabel = UILabel().then {
+    $0.text = "이(가)"
+    $0.textAlignment = .left
+    $0.font = .systemFont(ofSize: 13, weight: .regular)
   }
 
   private let stateLabel = UILabel().then {
@@ -52,12 +56,12 @@ final class BookAlertViewController: UIViewController {
     render()
   }
   init(_ image: UIImage,
-       _ guideText: String,
+       _ titleText: String,
        _ subGuideText: String,
        _ bookModel: BookModel) {
     super.init(nibName: nil, bundle: nil)
     stateImageView.image = image
-    titleLabel.text = guideText
+    titleLabel.text = titleText
     stateLabel.text = subGuideText
     data = bookModel
   }
@@ -107,6 +111,7 @@ extension BookAlertViewController {
     popUpView.adds([
       stateImageView,
       titleLabel,
+      guideLabel,
       stateLabel,
       submitButton
     ])
@@ -126,15 +131,20 @@ extension BookAlertViewController {
     }
 
     titleLabel.snp.makeConstraints { make in
-      make.centerX.equalTo(stateImageView)
-      make.leading.equalTo(popUpView).offset(30)
+      make.leading.lessThanOrEqualTo(popUpView).offset(55)
+      make.top.equalTo(stateImageView.snp.bottom).offset(20)
+    }
+
+    guideLabel.snp.makeConstraints { make in
+      make.trailing.equalTo(popUpView).offset(-55)
+      make.leading.equalTo(titleLabel.snp.trailing).offset(3)
       make.top.equalTo(stateImageView.snp.bottom).offset(20)
     }
 
     stateLabel.snp.makeConstraints { make in
       make.top.equalTo(titleLabel.snp.bottom).offset(6)
       make.leading.equalTo(popUpView).offset(40)
-      make.centerX.equalTo(titleLabel)
+      make.centerX.equalTo(stateImageView)
     }
 
     submitButton.snp.makeConstraints { make in


### PR DESCRIPTION
## 종류
- [ ] New Feature
- [ ] Change
- [x] Bug fix
- [ ] Setup (CI / CD)

## 개요
- 팝업화면과 서재탭 관련 QA 오류사항들을 수정했습니다.

## 변경 사항
- 팝업화면 시 책제목에 bold체 적용되도록 변경하였습니다.
- 서재화면 emptyview의 멘트 및 이미지가 제대로 안나타난다는 오류가 있어서 
그 부분들을 수정하였습니다. 
